### PR TITLE
Use read-only submodule url for heroku compatability

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/Requests"]
 	path = libs/Requests
-	url = git@github.com:rmccue/Requests.git
+	url = https://github.com/rmccue/Requests.git


### PR DESCRIPTION
Heroku doesn't have permission to read from the `git` protocol. This uses `https` instead.
